### PR TITLE
Temporarily disable fast deploys

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -9,7 +9,6 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
-  ENABLE_FAST_DEPLOYS: "true"
 
 jobs:
   dagster_cloud_default_deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ concurrency:
 env:
   DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
-  ENABLE_FAST_DEPLOYS: "true"
 
 jobs:
   dagster_cloud_default_deploy:


### PR DESCRIPTION
PEX is struggling to install the requirements for dbt. This means any new users who clones this project will see their initial build fail.

I'm temporarily falling back to our old Docker image deployment strategy instead. This means the initial build (and subsequent builds) will be slower - but they should succeed.