### PR TITLE
Pin packaging as a workaround to fix dbt-core deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "scipy",
         "dbt-core",
         "dbt-postgres",
+        "packaging<22.0",  # match dbt-core's requirement to workaround a resolution issue
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )


### PR DESCRIPTION
packaging 22.0 was released today and it seems to break pip resolution for this set of deps.